### PR TITLE
Folder Permissions

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func compressFiles(fPaths []string, path string, outputZip string) error {
 		writer, err := zipWriter.CreateHeader(&zip.FileHeader{
 			CreatorVersion: 3 << 8,     // indicates Unix
 			ExternalAttrs:  0777 << 16, // -rwxrwxrwx file permissions
-			Name:           fp,
+			Name:           filepath.Base(fp),
 			Method:         zip.Deflate,
 		})
 


### PR DESCRIPTION
Golang when creates the zip file, the folder permissions still don't have the adequate permissions. The solution is to put every file in the root directory of the zip.